### PR TITLE
Updating to debian-stretch base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM alpine:3.6
+FROM debian:stretch
 
-RUN apk --update upgrade && \
-    apk add --update bind && \
-    rm -rf /var/cache/apk/*
-
-RUN mkdir -p /var/cache/bind/zones && \
-    mkdir -p /var/cache/bind/config && \
-    mkdir -p /var/log/named
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install --no-install-recommends --no-install-suggests -y \
+		bind9 \
+		dnsutils \
+		iputils-ping \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps \
+	&& rm -r /var/lib/apt/lists/* \
+	&& mkdir /var/log/named \
+	&& chown bind:bind /var/log/named \
+	&& chmod 0755 /var/log/named
 
 # zones are copied in before running
 # the config directory should contain named.conf.local containing

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,16 +3,18 @@
 set -e
 
 echo "Copying zone files to /var/bind"
-cp -rf /var/cache/bind/zones/* /var/bind
+mkdir -p /var/bind
+cp -a /var/cache/bind/zones/. /var/bind/
 
 echo "Copying over named.conf.local"
 cp -rf /var/cache/bind/config/named.conf.local /etc/bind
 
 echo "Changing owner to named user"
-chown -R named:named /var/bind /etc/bind /var/run/named /var/log/named
+mkdir -m 0775 -p /var/run/named
+chown -R bind:bind /var/bind /etc/bind /var/run/named /var/log/named
 chmod -R o-rwx /var/bind /etc/bind /var/run/named /var/log/named
 
 START_UP=$(which named)
-echo "Starting bind at $START_UP -u named -c /etc/bind/named.conf -f"
+echo "Starting bind at $START_UP -u bind -c /etc/bind/named.conf -f"
 
-exec $(which named) -u named -c /etc/bind/named.conf -f
+exec $(which named) -u bind -c /etc/bind/named.conf -f

--- a/files/bind/named.conf
+++ b/files/bind/named.conf
@@ -6,31 +6,10 @@ include "/etc/bind/named.conf.options";
 include "/etc/bind/named.conf.local";
 
 logging {
-    channel general {
-        file "/var/log/named/general.log" versions 5;
-        print-time yes;
-        print-category yes;
-        print-severity yes;
-    };
-
-    channel queries {
-        file "/var/log/named/queries.log" versions 5 size 10m;
-        print-time yes;
-        print-category yes;
-        print-severity yes;
-    };
-
-    channel security {
-        file "/var/log/named/security.log" versions 5;
-        print-time yes;
-        print-category yes;
-        print-severity yes;
-    };
-
-    category default { general; };
-    category general { general; };
-    category config { general; };
-    category network { general; };
-    category queries { queries; };
-    category security { security; };
+    category default { default_stderr; };
+    category general { default_stderr; };
+    category config { default_stderr; };
+    category network { default_stderr; };
+    category queries { default_stderr; };
+    category security { default_stderr; };
 };

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Starting up docker compose with example zones"
+docker-compose up -d --force-recreate --build
+if [ $? -ne 0 ]; then
+  echo "Failed starting up docker compose!"
+  exit 1
+fi
+
+dig @localhost www.example.com -p 5333
+if [ $? -ne 0 ]; then
+  echo "Unable to find sample zone on bind9 server, failed!"
+  exit 1
+fi
+
+echo "Test successful!"
+echo "Shutting down docker container..."
+docker-compose down -v


### PR DESCRIPTION
- Updated Dockerfile to use debian-stretch
- Subtle tweaks to entrypoint for copying files needed
- Changed logging to print to stdout for bind9
- Added simple test build script to test the image

1. Checkout the branch
2. Run `./test.sh`