### PR TITLE
Override more config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This image _copies_ over configuration to the bind 9 image before starting the b
 
 The volume `/var/cache/bind/zones` contains your zone files.  These are copied onto the container to `/var/bind`
 
-The volume `/var/cache/bind/config` should contain a single file `named.conf.local`.  This file is copied over to `/etc/bind` and will _replace_ the existing `named.conf.local` that is currently empty.  
+The volume `/var/cache/bind/config` should contain at least a single file `named.conf.local`.  All `named.conf.*` files in this directory are copied over to `/etc/bind` and will _replace_ the existing files of the same name. 
 
 > If you do not mount both, then the bind9 server may start up without any zones
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,8 @@ echo "Copying zone files to /var/bind"
 mkdir -p /var/bind
 cp -a /var/cache/bind/zones/. /var/bind/
 
-echo "Copying over named.conf.local"
-cp -rf /var/cache/bind/config/named.conf.local /etc/bind
+echo "Copying over named.conf files"
+cp -rf /var/cache/bind/config/named.conf.* /etc/bind
 
 echo "Changing owner to named user"
 mkdir -m 0775 -p /var/run/named


### PR DESCRIPTION
Support any `named.conf.*` files in `/var/cache/bind/config`.